### PR TITLE
Add bic_swift to Instruments not required

### DIFF
--- a/app/Services/EDocument/Adapters/CII/PaymentMeans.php
+++ b/app/Services/EDocument/Adapters/CII/PaymentMeans.php
@@ -363,7 +363,9 @@ class PaymentMeans implements PaymentMeansInterface
     ];
 
     public static array $payment_means_requirements_codes = [
-        '1' => [], // Instrument not defined
+        '1' => [
+            'bic_swift',
+        ], // Instrument not defined
         '2' => [
             'iban',
             'bic_swift'


### PR DESCRIPTION
Perhaps we should require bic_swift whenever IBAN is required, but since we have no cases following this and all requirements are derived exclusively from `payment_means_requirements_codes`, this just updates that.

Demo:

https://github.com/user-attachments/assets/fb774fd8-e1e1-4969-9906-e016f9778440

