### PR TITLE
Complete api request body schemas

### DIFF
--- a/openapi/components/schemas/credit_invitation.yaml
+++ b/openapi/components/schemas/credit_invitation.yaml
@@ -1,0 +1,57 @@
+    CreditInvitation:
+      properties:
+        id:
+          description: 'The entity invitation hashed id'
+          type: string
+          example: Opnel5aKBz
+          readOnly: true
+        client_contact_id: 
+          description: 'The client contact hashed id'
+          type: string
+          example: Opnel5aKBz
+        key:
+          description: 'The invitation key'
+          type: string
+          example: Opnel5aKBz4343343566236gvbb
+          readOnly: true
+        link:
+          description: 'The invitation link'
+          type: string
+          example: 'https://www.example.com/invitations/Opnel5aKBz4343343566236gvbb'
+          readOnly: true
+        sent_date:
+          description: 'The invitation sent date'
+          type: string
+          format: date-time
+          readOnly: true
+        viewed_date:
+          description: 'The invitation viewed date'
+          type: string
+          format: date-time
+          readOnly: true
+        opened_date:
+          description: 'The invitation opened date'
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          description: 'Timestamp'
+          type: number
+          format: integer
+          example: '1434342123'
+          readOnly: true
+        archived_at:
+          description: 'Timestamp'
+          type: number
+          format: integer
+          example: '1434342123'
+          readOnly: true
+        email_error:
+          description: 'The email error'
+          type: string
+          example: 'The email error'
+          readOnly: true
+        email_status:
+          description: 'The email status'
+          type: string
+          readOnly: true

--- a/openapi/components/schemas/invoice.yaml
+++ b/openapi/components/schemas/invoice.yaml
@@ -1,0 +1,241 @@
+    Invoice:
+      properties:
+        id:
+          description: 'The invoice hashed id'
+          type: string
+          example: Opnel5aKBz
+          readOnly: true
+        user_id:
+          description: 'The user hashed id'
+          type: string
+          example: Opnel5aKBz
+          readOnly: true
+        assigned_user_id:
+          description: 'The assigned user hashed id'
+          type: string
+          example: Opnel5aKBz
+        client_id:
+          description: 'The client hashed id'
+          type: string
+          example: Opnel5aKBz
+        status_id:
+          description: 'The invoice status variable'
+          type: string
+          example: '4'
+        number:
+          description: 'The invoice number - is a unique alpha numeric number per invoice per company'
+          type: string
+          example: INV_101
+        po_number:
+          description: 'The purchase order associated with this invoice'
+          type: string
+          example: PO-1234
+        terms:
+          description: 'The invoice terms'
+          type: string
+          example: 'These are invoice terms'
+        public_notes:
+          description: 'The public notes of the invoice'
+          type: string
+          example: 'These are some public notes'
+        private_notes:
+          description: 'The private notes of the invoice'
+          type: string
+          example: 'These are some private notes'
+        footer:
+          description: 'The invoice footer notes'
+          type: string
+          example: ''
+        custom_value1:
+          description: 'A custom field value'
+          type: string
+          example: '2022-10-01'
+        custom_value2:
+          description: 'A custom field value'
+          type: string
+          example: 'Something custom'
+        custom_value3:
+          description: 'A custom field value'
+          type: string
+          example: ''
+        custom_value4:
+          description: 'A custom field value'
+          type: string
+          example: ''
+        tax_name1:
+          description: 'The tax name'
+          type: string
+          example: ''
+        tax_name2:
+          description: 'The tax name'
+          type: string
+          example: ''
+        tax_rate1:
+          description: 'The tax rate'
+          type: number
+          format: float
+          example: '10.00'
+        tax_rate2:
+          description: 'The tax rate'
+          type: number
+          format: float
+          example: '10.00'
+        tax_name3:
+          description: 'The tax name'
+          type: string
+          example: ''
+        tax_rate3:
+          description: 'The tax rate'
+          type: number
+          format: float
+          example: '10.00'
+        total_taxes:
+          description: 'The total taxes for the invoice'
+          type: number
+          format: float
+          example: '10.00'
+        line_items:
+          type: array
+          description: 'An array of objects which define the line items of the invoice'
+          items:
+            $ref: '#/components/schemas/InvoiceItem'
+        invitations:
+          type: array
+          description: 'An array of objects which define the invitations of the invoice'
+          items:
+            $ref: '#/components/schemas/InvoiceInvitation'
+        amount:
+          description: 'The invoice amount'
+          type: number
+          format: float
+          example: '10.00'
+        balance:
+          description: 'The invoice balance'
+          type: number
+          format: float
+          example: '10.00'
+        paid_to_date:
+          description: 'The amount paid on the invoice to date'
+          type: number
+          format: float
+          example: '10.00'
+        discount:
+          description: 'The invoice discount, can be an amount or a percentage'
+          type: number
+          format: float
+          example: '10.00'
+        partial:
+          description: 'The deposit/partial amount'
+          type: number
+          format: float
+          example: '10.00'
+        is_amount_discount:
+          description: 'Flag determining if the discount is an amount or a percentage'
+          type: boolean
+          example: true
+        is_deleted:
+          description: 'Defines if the invoice has been deleted'
+          type: boolean
+          example: true
+        uses_inclusive_taxes:
+          description: 'Defines the type of taxes used as either inclusive or exclusive'
+          type: boolean
+          example: true
+        date:
+          description: 'The Invoice Date'
+          type: string
+          format: date
+          example: '1994-07-30'
+        last_sent_date:
+          description: 'The last date the invoice was sent out'
+          type: string
+          format: date
+          example: '1994-07-30'
+        next_send_date:
+          description: 'The Next date for a reminder to be sent'
+          type: string
+          format: date
+          example: '1994-07-30'
+        partial_due_date:
+          description: 'The due date for the deposit/partial amount'
+          type: string
+          format: date
+          example: '1994-07-30'
+        due_date:
+          description: 'The due date of the invoice'
+          type: string
+          format: date
+          example: '1994-07-30'
+        last_viewed:
+          description: Timestamp
+          type: number
+          format: integer
+          example: '1434342123'
+        updated_at:
+          description: Timestamp
+          type: number
+          format: integer
+          example: '1434342123'
+        archived_at:
+          description: Timestamp
+          type: number
+          format: integer
+          example: '1434342123'
+        custom_surcharge1:
+          description: 'First Custom Surcharge'
+          type: number
+          format: float
+          example: '10.00'
+        custom_surcharge2:
+          description: 'Second Custom Surcharge'
+          type: number
+          format: float
+          example: '10.00'
+        custom_surcharge3:
+          description: 'Third Custom Surcharge'
+          type: number
+          format: float
+          example: '10.00'
+        custom_surcharge4:
+          description: 'Fourth Custom Surcharge'
+          type: number
+          format: float
+          example: '10.00'
+        custom_surcharge_tax1:
+          description: 'Toggles charging taxes on custom surcharge amounts'
+          type: boolean
+          example: true
+        custom_surcharge_tax2:
+          description: 'Toggles charging taxes on custom surcharge amounts'
+          type: boolean
+          example: true
+        custom_surcharge_tax3:
+          description: 'Toggles charging taxes on custom surcharge amounts'
+          type: boolean
+          example: true
+        custom_surcharge_tax4:
+          description: 'Toggles charging taxes on custom surcharge amounts'
+          type: boolean
+          example: true
+        project_id:
+          description: 'The project associated with this invoice'
+          type: string
+          example: Opnel5aKBz
+        auto_bill_tries:
+          description: 'The number of times the invoice has attempted to be auto billed'
+          type: integer
+          example: '1'
+          readOnly: true
+        auto_bill_enabled:
+          description: 'Boolean flag determining if the invoice is set to auto bill'
+          type: boolean
+          example: true
+        subscription_id:
+          description: 'The subscription associated with this invoice'
+          type: string
+          example: Opnel5aKBz
+        location_id:
+          description: 'The client location id that this invoice relates to'
+          type: string
+          example: Opnel5aKBz
+      type: object


### PR DESCRIPTION
Add base OpenAPI schemas for CreditInvitation and Invoice to establish the style guide and foundational components for identifying and creating missing request body definitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-24974dc9-e0b9-43cb-9026-ac242a4532ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24974dc9-e0b9-43cb-9026-ac242a4532ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

